### PR TITLE
[fixed] objectpool에 두 번 반환하던 문제 해결

### DIFF
--- a/Assets/Scripts/Data/CollisionFunctions/Destroyer.cs
+++ b/Assets/Scripts/Data/CollisionFunctions/Destroyer.cs
@@ -8,12 +8,14 @@ public class Destroyer : CollisionInteraction
 {
     public override void EnterCollsion(GameObject Owner,GameObject target)
     {
-
-        PooledObject pool = target.GetComponent<PooledObject>();
-        if (pool.OnRelease != null)
-            pool.OnRelease(target);
-        else
-            Destroy(target);
+        if (target.activeSelf)
+        {
+            PooledObject pool = target.GetComponent<PooledObject>();
+            if (pool.OnRelease != null)
+                pool.OnRelease(target);
+            else
+                Destroy(target);            
+        }
     }
 
     public override void ExitCollsion(GameObject who, GameObject target)

--- a/Assets/Scripts/Data/CollisionFunctions/SelfDestroy.cs
+++ b/Assets/Scripts/Data/CollisionFunctions/SelfDestroy.cs
@@ -10,11 +10,13 @@ public class SelfDestroy : CollisionInteraction
     public override void EnterCollsion(GameObject Owner, GameObject target)
     {
         PooledObject pool = Owner.GetComponent<PooledObject>();
-        
-        if (pool.OnRelease!= null)
-            pool.OnRelease.Invoke(Owner);
-        else
-            Destroy(Owner);
+        if (target.activeSelf)
+        {
+            if (pool.OnRelease != null)
+                pool.OnRelease.Invoke(Owner);
+            else
+                Destroy(Owner);
+        }
     }
 
     public override void ExitCollsion(GameObject who, GameObject target)


### PR DESCRIPTION
Destroyer와 SelfDestroy가 기능이 겹쳐서 그랬던 것,  OnRelease를 할 때는 active 상태임을 꼭 확인할 것